### PR TITLE
Remove non error or debugging logging

### DIFF
--- a/client/reporter.go
+++ b/client/reporter.go
@@ -47,7 +47,7 @@ outerloop:
 				"userInECU":  point.UserInECU(instance),
 				"sysInECU":   point.SysInECU(instance),
 				"memoryInKB": point.Memory,
-			}).Info("Got point")
+			}).Debug("Got point")
 		}
 	}
 }

--- a/dmesg/stream.go
+++ b/dmesg/stream.go
@@ -1,7 +1,9 @@
 package dmesg
 
-import "time"
-import "log"
+import (
+  "time"
+  log "github.com/Sirupsen/logrus"
+)
 
 // Stream creates a goroutine that, every sampleTime ticks, will send
 // new dmesg messages to out.  It also listens on stop, in case you
@@ -24,7 +26,7 @@ func doStream(state *State, out chan<- *Message, stop <-chan bool, sampleTime ti
 	for _ = range ticker.C {
 		select {
 		case <-stop:
-			log.Println("Terminating as requested")
+			log.Debug("Terminating as requested")
 			return
 		default:
 		}
@@ -39,7 +41,7 @@ func doStream(state *State, out chan<- *Message, stop <-chan bool, sampleTime ti
 				hasSeenLast := false
 				for _, message := range messages {
 					if message.Timestamp.After(lastMessage.Timestamp) {
-						log.Println("missed some, resuming where available")
+						log.Debug("missed some, resuming where available")
 						hasSeenLast = true
 					} else if message == lastMessage {
 						hasSeenLast = true
@@ -51,7 +53,7 @@ func doStream(state *State, out chan<- *Message, stop <-chan bool, sampleTime ti
 				}
 			}
 		} else {
-			log.Println("Messages returned error; hoping it clears up")
+			log.Warning("Messages returned error; hoping it clears up")
 		}
 	}
 }


### PR DESCRIPTION
https://github.com/meteor/procmon/issues/1
This logs rather a lot of data, logging every single timepoint it sees. This is probably causing us trouble with logly. This PR is attempting to remove extranious logging in non-debug mode.
